### PR TITLE
Match versions in RP nodes. Bump console, too.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,7 +35,7 @@ services:
 
   # Want a two node Redpanda cluster? Uncomment this block :)
   # redpanda-2:
-  #   image: docker.redpanda.com/vectorized/redpanda:v23.1.8
+  #   image: docker.redpanda.com/redpandadata/redpanda:v23.1.8
   #   container_name: redpanda-2
   #   command:
   #     - redpanda
@@ -66,7 +66,7 @@ services:
   #     - 9093:9093
 
   redpanda-console:
-    image: docker.redpanda.com/vectorized/console:v2.2.4
+    image: docker.redpanda.com/redpandadata/console:v2.2.4
     container_name: redpanda-console
     entrypoint: /bin/sh
     command: -c "echo \"$$CONSOLE_CONFIG_FILE\" > /tmp/config.yml; /app/console"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.7'
 services:
   # Redpanda cluster
   redpanda-1:
-    image: docker.redpanda.com/redpandadata/redpanda:v23.1.7
+    image: docker.redpanda.com/redpandadata/redpanda:v23.1.8
     container_name: redpanda-1
     command:
       - redpanda
@@ -35,7 +35,7 @@ services:
 
   # Want a two node Redpanda cluster? Uncomment this block :)
   # redpanda-2:
-  #   image: docker.redpanda.com/vectorized/redpanda:v22.3.5
+  #   image: docker.redpanda.com/vectorized/redpanda:v23.1.8
   #   container_name: redpanda-2
   #   command:
   #     - redpanda
@@ -66,7 +66,7 @@ services:
   #     - 9093:9093
 
   redpanda-console:
-    image: docker.redpanda.com/vectorized/console:v2.1.1
+    image: docker.redpanda.com/vectorized/console:v2.2.4
     container_name: redpanda-console
     entrypoint: /bin/sh
     command: -c "echo \"$$CONSOLE_CONFIG_FILE\" > /tmp/config.yml; /app/console"
@@ -100,7 +100,7 @@ services:
     environment:
       - |
         FLINK_PROPERTIES=
-        jobmanager.rpc.address: jobmanager        
+        jobmanager.rpc.address: jobmanager
 
   taskmanager:
     container_name: taskmanager
@@ -116,7 +116,7 @@ services:
         FLINK_PROPERTIES=
         jobmanager.rpc.address: jobmanager
         taskmanager.numberOfTaskSlots: 20
-       
+
   sql-client:
     container_name: sql-client
     build:


### PR DESCRIPTION
I noticed the `redpanda-2` node didn't get the version bump during the last update. While here, I bumped to the latest patch releases and also bumped the console. 